### PR TITLE
sensors.service: Add systemd service

### DIFF
--- a/sensors.service
+++ b/sensors.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Publish sensor data
+After=mosquitto.service
+Wants=mosquitto.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/sensors.py
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add systemd service for starting sensors.py in an embedded Linux distribution after Mosquitto MQTT broker.